### PR TITLE
upgrade traefik to auto-resolve docker version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -46,7 +46,7 @@ services:
     build:
       context: ./services/traefik
       args:
-        TRAEFIK_VERSION: ${TRAEFIK_VERSION:-v3.5.2}
+        TRAEFIK_VERSION: ${TRAEFIK_VERSION:-v3.6.1}
     restart: unless-stopped
     depends_on:
       mkcert:


### PR DESCRIPTION
fix traefik error:

```
traefik-1    | 2026-02-23T20:56:44Z ERR Failed to retrieve information of the docker client and server host error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version" providerName=docker
```

see https://github.com/traefik/traefik/pull/12256